### PR TITLE
activemodel を development_dependency から通常の依存 gem に移動

### DIFF
--- a/dymos.gemspec
+++ b/dymos.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fake_dynamo"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "activemodel", '~> 4.1.5'
 
+  spec.add_dependency "activemodel", '~> 4.1.5'
   spec.add_dependency "aws-sdk-core"
 end

--- a/lib/dymos/version.rb
+++ b/lib/dymos/version.rb
@@ -1,3 +1,3 @@
 module Dymos
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
gem install で入れると以下の様なエラーが出たため，activemodel を依存 gem に加えた

``````
/Users/hash/git/clone/github.com/hoshina85/dymos/lib/dymos/model.rb:2:in `require': cannot load such file -- active_model (LoadError)
        from /Users/hash/git/clone/github.com/hoshina85/dymos/lib/dymos/model.rb:2:in `<top (required)>'
        from /Users/hash/git/clone/github.com/hoshina85/dymos/lib/dymos.rb:16:in `require'
        from /Users/hash/git/clone/github.com/hoshina85/dymos/lib/dymos.rb:16:in `<top (required)>'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `require'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `each'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `block in require'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `each'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `require'
        from /Users/hash/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.10.6/lib/bundler.rb:134:in `require'
        ...
``````